### PR TITLE
Add workflow that publishes Chirp:

### DIFF
--- a/.github/workflows/publish_chirp.yml
+++ b/.github/workflows/publish_chirp.yml
@@ -1,0 +1,81 @@
+# This workflow will build a .NET project and create GitHub releases for each tag
+
+name: .NET Release Chirp
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+
+      - name: Build for Windows
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          release_name="Chirp-$tag-win-x64"
+
+          # Build everything
+          dotnet publish Chirp.CLI/Chirp.CLI.csproj --runtime win-x64 -c Release -o "$release_name" --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          
+          # Path to the executable to include
+          executable_path="./${release_name}/Chirp.CLI.exe"
+          
+          # Pack to zip for Windows
+          7z a -tzip "${release_name}.zip" "$executable_path"
+
+      - name: Build for Linux
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          release_name="Chirp-$tag-linux-x64"
+
+          # Build everything
+          dotnet publish Chirp.CLI/Chirp.CLI.csproj --runtime linux-x64 -c Release -o "$release_name" --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          
+          # Path to the executable to include
+          executable_path="./${release_name}/Chirp.CLI.exe"
+          
+          # Pack to tar for Linux
+          tar czvf "${release_name}.tar.gz" "$release_name"
+
+      - name: Build for Mac
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          release_name="Chirp-$tag-osx-x64"
+
+          # Build everything
+          dotnet publish Chirp.CLI/Chirp.CLI.csproj --runtime osx-x64 -c Release -o "$release_name" --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          
+          # Path to the executable to include
+          executable_path="./${release_name}/Chirp.CLI.exe"
+          
+          # Pack to tar for Mac
+          tar czvf "${release_name}.tar.gz" "$release_name"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            Chirp-*.zip
+            Chirp-*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* When an accordingly tagged version is pushed
* Publishes for windows, linux and mac OS